### PR TITLE
Fix 'invalid HMAC key' error for buffers

### DIFF
--- a/index.js
+++ b/index.js
@@ -116,8 +116,12 @@ var isInvalidShape = exports.isInvalidShape = function (msg) {
 const isInvalidHmacKey = (hmacKey) => {
   if (hmacKey === undefined) return false
   if (hmacKey === null) return false
-  const bytes = Buffer.from(hmacKey, 'base64')
-  if (bytes.toString('base64') !== hmacKey) return true
+  const bytes = Buffer.isBuffer(hmacKey) ? hmacKey : Buffer.from(hmacKey, 'base64')
+
+  if (typeof hmacKey === 'string') {
+    if (bytes.toString('base64') !== hmacKey) return true
+  }
+
   if (bytes.length !== 32) return true
   return false
 }

--- a/test/error.js
+++ b/test/error.js
@@ -370,3 +370,4 @@ function test (hmac_key) {
 test()
 test(hash('hmac_key').toString('base64'))
 test(hash('hmac_key2').toString('base64'))
+test(hash('hmac_key3'))


### PR DESCRIPTION
Problem: Previous versions of this module allowed HMAC keys as buffers,
but there weren't any tests or documentation which meant that they were
eventually broken.

Solution: Add a test to identify the problem and fix the HMAC key
validation function to ensure that it validates HMAC keys that are
expressed as buffers.

Fixes: https://github.com/ssb-js/ssb-validate/issues/23