### PR TITLE
Remove extra dependencies with depcheck

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,6 @@
     "ssb-ref": "^2.6.2"
   },
   "devDependencies": {
-    "flumecodec": "0.0.0",
-    "flumedb": "^0.3.1",
-    "flumelog-offset": "^3.0.3",
     "pull-stream": "^3.6.0",
     "ssb-client": "^4.5.0",
     "ssb-validation-dataset": "^1.2.1",


### PR DESCRIPTION
This removes the extra dependencies and reinstates the lockfile, which
(IIRC) was one of Dominic's preferences. I'd much prefer to have a
lockfile history so that we can `npm ci` and be able to actually
reproduce previous commits.